### PR TITLE
fix: add kickstart dependencies to coc Dockerfile

### DIFF
--- a/coc/Dockerfile
+++ b/coc/Dockerfile
@@ -3,10 +3,7 @@ FROM try.nvim:$TAG
 
 # To support kickstart.nvim
 RUN apk --no-cache add \
-    fd  \
-    ctags \
-    ripgrep \
-    git
+    ctags
 
 # Add nodejs dependency for servers
 RUN apk --no-cache add \

--- a/coc/Dockerfile
+++ b/coc/Dockerfile
@@ -1,6 +1,13 @@
 ARG TAG=base-stable
 FROM try.nvim:$TAG
 
+# To support kickstart.nvim
+RUN apk --no-cache add \
+    fd  \
+    ctags \
+    ripgrep \
+    git
+
 # Add nodejs dependency for servers
 RUN apk --no-cache add \
     git \


### PR DESCRIPTION
Get a "Executable 'ctags' can't be found." error as soon as a file is
opened.